### PR TITLE
Added ifremer

### DIFF
--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -12,6 +12,13 @@ OptionalStr = Optional[str]
 # We aim to support more sources in the near future.
 _server = "https://gliders.ioos.us/erddap"
 
+ifremer_vars = ['time',
+ 'latitude',
+ 'longitude',
+ 'PSAL',
+ 'TEMP',
+ 'PRES',
+ 'platform_deployment']
 
 class GliderDataFetcher(object):
     """
@@ -24,16 +31,19 @@ class GliderDataFetcher(object):
 
     """
 
-    def __init__(self):
-        self.fetcher = ERDDAP(server=_server, protocol="tabledap",)
-        self.fetcher.variables = [
-            "depth",
-            "latitude",
-            "longitude",
-            "salinity",
-            "temperature",
-            "time",
-        ]
+    def __init__(self, server=_server):
+        self.fetcher = ERDDAP(server=server, protocol="tabledap",)
+        if "ifremer" in self.fetcher.server:
+            self.fetcher.variables = ifremer_vars
+        else:
+            self.fetcher.variables = [
+                "depth",
+                "latitude",
+                "longitude",
+                "salinity",
+                "temperature",
+                "time",
+            ]
         self.fetcher.dataset_id: OptionalStr = None
 
     def to_pandas(self):
@@ -66,6 +76,15 @@ class GliderDataFetcher(object):
         }
         return self
 
+    def platform(self, platform):
+        """
+
+        :param platform: platform and deployment id from ifremer
+        :return: search query with platform constraint applied
+        """
+        self.fetcher.constraints['platform_deployment='] = platform
+        return self
+
 class DatasetList:
     """ Search servers for glider dataset ids. Defaults to the string "glider"
 
@@ -76,8 +95,8 @@ class DatasetList:
 
     """
 
-    def __init__(self):
-        self.e = ERDDAP(server="https://gliders.ioos.us/erddap", protocol="tabledap",)
+    def __init__(self, server=_server):
+        self.e = ERDDAP(server=server, protocol="tabledap",)
         self.search_terms = ["glider"]
 
     def get_ids(self):

--- a/notebooks/non_ioos_sources.ipynb
+++ b/notebooks/non_ioos_sources.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importing data from other ERDDAP servers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "notebook_dir = !pwd\n",
+    "sys.path.append(str( Path(notebook_dir[0]).parent.absolute()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gliderpy.fetchers import GliderDataFetcher\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ifremer \n",
+    "\n",
+    "http://www.ifremer.fr/erddap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pull all glider data from a week in September 2015"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glider_grab = GliderDataFetcher(\"http://www.ifremer.fr/erddap\")\n",
+    "glider_grab.fetcher.dataset_id = \"OceanGlidersGDACTrajectories\"\n",
+    "glider_grab.query(-90, 90, -180, 180, \"2015-09-20\", \"2015-09-27\")\n",
+    "df = glider_grab.to_pandas()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.unique(df.platform_deployment.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that this dataset includes three glider deployments, we plot their locations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(df[\"longitude (degrees_east)\"],df[\"latitude (degrees_north)\"] )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First find out what datasets are available on this server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gliderpy.fetchers import DatasetList\n",
+    "\n",
+    "datasets = DatasetList(\"http://www.ifremer.fr/erddap\")\n",
+    "ds_ids = datasets.get_ids()\n",
+    "\n",
+    "print(f'found {len(ds_ids)} datasets matching the search terms {datasets.search_terms} on the server {datasets.e.server}')\n",
+    "ds_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In contrast to IOOS, Ifremer stores all its glider data in one table\n",
+    "\n",
+    "We can specify a single glider  deployment with the `platform` method from `GliderDataFetcher`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glider_grab = GliderDataFetcher(\"http://www.ifremer.fr/erddap\")\n",
+    "glider_grab.fetcher.dataset_id = \"OceanGlidersGDACTrajectories\"\n",
+    "glider_grab.query(0, 80, -170, 170, \"2015-09-20T01:00:00\", \"25th sept 2015\")\n",
+    "glider_grab.platform(\"Laphroaig_489\")\n",
+    "df = glider_grab.to_pandas()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.unique(df.platform_deployment.values)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I have added functionality in the GliderDataFetcher class to specify the server. Defaults to IOOS.

If the user supplies the ifermer ERDDAP, a different set of variables is requested so satisfy ifremer's naming conventions (TEMP rather than temperature etc.)

Ifremer stores all glider data in one big table, so I have added a method where the user can specify the glider deployment with a string.

Finally I have made a new notebook demonstrating the above functionality.