### PR TITLE
friendly server names with string matching function

### DIFF
--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -13,22 +13,13 @@ import pandas as pd
 
 from erddapy import ERDDAP
 
+from gliderpy.servers import server_select, server_vars
+
 
 OptionalStr = Optional[str]
 
-# This is hardcoded to the IOOS glider DAC.
-# We aim to support more sources in the near future.
+# This defaults to the IOOS glider DAC.
 _server = "https://gliders.ioos.us/erddap"
-
-ifremer_vars = [
-    "time",
-    "latitude",
-    "longitude",
-    "PSAL",
-    "TEMP",
-    "PRES",
-    "platform_deployment",
-]
 
 
 class GliderDataFetcher(object):
@@ -43,21 +34,12 @@ class GliderDataFetcher(object):
     """
 
     def __init__(self, server=_server):
+        server = server_select(server)
         self.fetcher = ERDDAP(
             server=server,
             protocol="tabledap",
         )
-        if "ifremer" in self.fetcher.server:
-            self.fetcher.variables = ifremer_vars
-        else:
-            self.fetcher.variables = [
-                "depth",
-                "latitude",
-                "longitude",
-                "salinity",
-                "temperature",
-                "time",
-            ]
+        self.fetcher.variables = server_vars[server]
         self.fetcher.dataset_id: OptionalStr = None
 
     def to_pandas(self):

--- a/gliderpy/servers.py
+++ b/gliderpy/servers.py
@@ -1,0 +1,68 @@
+"""
+Server names and aliases that point to an ERDDAP instance
+
+"""
+
+
+server_alias = {
+    "National Glider Data Assembly Center": "https://gliders.ioos.us/erddap",
+    "NGDAC": "https://gliders.ioos.us/erddap",
+    "IOOS": "https://gliders.ioos.us/erddap",
+    "Ocean Observatories Initiative": "https://erddap-uncabled.oceanobservatories.org/uncabled/erddap",
+    "OOI": "https://erddap-uncabled.oceanobservatories.org/uncabled/erddap",
+    "Institut français de recherche pour l'exploitation de la mer": "http://www.ifremer.fr/erddap",
+    "ifremer": "http://www.ifremer.fr/erddap",
+    "ifremer.fr": "http://www.ifremer.fr/erddap",
+}
+
+server_vars = {
+    "https://gliders.ioos.us/erddap": [
+        "depth",
+        "latitude",
+        "longitude",
+        "salinity",
+        "temperature",
+        "time",
+    ],
+    "http://www.ifremer.fr/erddap": [
+        "time",
+        "latitude",
+        "longitude",
+        "PSAL",
+        "TEMP",
+        "PRES",
+        "platform_deployment",
+    ],
+    "https://erddap-uncabled.oceanobservatories.org/uncabled/erddap": [
+        "latitude",
+        "longitude",
+        "ctdgv_m_glider_instrument_practical_salinity",
+        "ctdgv_m_glider_instrument_sci_water_temp",
+        "ctdgv_m_glider_instrument_sci_water_pressure_dbar",
+        "time",
+        "quality_flag",
+        "trajectory",
+    ],
+}
+
+
+def server_select(server_string):
+    """
+    Attempts to match the supplied string to a known ERDDAP server by address or alias
+    """
+    if server_string in server_vars.keys():
+        # If string matches exactly, return unchanged
+        return server_string
+    for server in server_vars.keys():
+        # If string contains base ERDDAP address, return base ERDDAP address
+        if server in server_string:
+            return server
+    for alias in server_alias:
+        # If string matches one of the aliases, return the corresponding ERDDAP address
+        if server_string.lower() == alias.lower():
+            return server_alias[alias]
+    # If the server is not recognised, print options of working servers and exit
+    raise ValueError(
+        "Supplied server/alias not recognised. Please use one of the following supported servers:\n"
+        + str(server_vars.keys())[10:-1]
+    )

--- a/gliderpy/servers.py
+++ b/gliderpy/servers.py
@@ -64,5 +64,5 @@ def server_select(server_string):
     # If the server is not recognised, print options of working servers and exit
     raise ValueError(
         "Supplied server/alias not recognised. Please use one of the following supported servers:\n"
-        + str(server_vars.keys())[10:-1]
+        f"{str(server_vars.keys())[10:-1]}"
     )


### PR DESCRIPTION
A first attempt at implementing friendly server names. The magic happens in the new servers.py file.

The logic is laid out in the function `server_select`. This tries various matches to the user supplied string:

If it matches a server http exactly, return unchanged
If it matches a server http, but has extra stuff on the end, return the server http only
If it matches a common alias e.g IOOS or ifremer, return the corresponding server (case insensitive)
If no match can be made, raise a ValueError and return a list of supported servers

The works for all the cases in Issue #38

I could be barking up the wrong tree with this. But if it makes sense as an implementation I'll write some tests for it