### PR TITLE
return table of datasets in query bounds

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = erddapy,pandas,pytest,setuptools
+known_third_party = erddapy,pandas,pytest,requests,setuptools

--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -8,8 +8,9 @@ import functools
 from typing import Optional
 
 import pandas as pd
-
+import requests
 from erddapy import ERDDAP
+from erddapy.url_handling import urlopen
 
 from gliderpy.servers import server_parameter_rename, server_select, server_vars
 
@@ -59,7 +60,7 @@ class GliderDataFetcher(object):
         df["dataset_url"] = dataset_url
         return df
 
-    def query(self, min_lat, max_lat, min_lon, max_lon, start_time, end_time):
+    def query(self, min_lat, max_lat, min_lon, max_lon, min_time, max_time):
         """
         Takes user supplied geographical and time constraints and adds them to the query
 
@@ -67,18 +68,26 @@ class GliderDataFetcher(object):
         :param max_lat: northermost lat
         :param min_lon: westernmost lon (-180 to +180)
         :param max_lon: easternmost lon (-180 to +180)
-        :param start_time: start time, can be datetime object or string
-        :param end_time: end time, can be datetime object or string
+        :param min_time: start time, can be datetime object or string
+        :param max_time: end time, can be datetime object or string
         :return: search query with argument constraints applied
         """
         self.fetcher.constraints = {
-            "time>=": start_time,
-            "time<=": end_time,
+            "time>=": min_time,
+            "time<=": max_time,
             "latitude>=": min_lat,
             "latitude<=": max_lat,
             "longitude>=": min_lon,
             "longitude<=": max_lon,
         }
+        if not self.fetcher.dataset_id:
+            url = self.fetcher.get_search_url(search_for='glider', response="csv", min_lat=min_lat, max_lat=max_lat, min_lon=min_lon, max_lon=max_lon, min_time=min_time, max_time=max_time)
+            try:
+                data = urlopen(url)
+            except requests.exceptions.HTTPError:
+                print("Error, no datasets found in supplied range. Try relaxing your constraints")
+                return
+            return pd.read_csv(data)
         return self
 
     def platform(self, platform):

--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import pandas as pd
 import requests
+
 from erddapy import ERDDAP
 from erddapy.url_handling import urlopen
 
@@ -81,13 +82,26 @@ class GliderDataFetcher(object):
             "longitude<=": max_lon,
         }
         if not self.fetcher.dataset_id:
-            url = self.fetcher.get_search_url(search_for='glider', response="csv", min_lat=min_lat, max_lat=max_lat, min_lon=min_lon, max_lon=max_lon, min_time=min_time, max_time=max_time)
+            url = self.fetcher.get_search_url(
+                search_for="glider",
+                response="csv",
+                min_lat=min_lat,
+                max_lat=max_lat,
+                min_lon=min_lon,
+                max_lon=max_lon,
+                min_time=min_time,
+                max_time=max_time,
+            )
             try:
                 data = urlopen(url)
             except requests.exceptions.HTTPError:
-                print("Error, no datasets found in supplied range. Try relaxing your constraints")
+                print(
+                    "Error, no datasets found in supplied range. Try relaxing your constraints"
+                )
                 return
-            return pd.read_csv(data)
+            df = pd.read_csv(data)
+            return df[["Title", "Institution", "Dataset ID"]]
+
         return self
 
     def platform(self, platform):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 erddapy
+pandas
+requests
+setuptools


### PR DESCRIPTION
If a user runs `GliderDataFetcher.query` without a dataset_id specified, it will search the server for datasets within the bounds of the query and return a pandas dataframe of these dataset ids