### PR TITLE
Refactor `urlopen` import

### DIFF
--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pandas as pd
 import requests
 from erddapy import ERDDAP
-from erddapy.url_handling import urlopen
+from erddapy.erddapy import urlopen
 
 from gliderpy.servers import server_parameter_rename, server_select, server_vars
 


### PR DESCRIPTION
Hi,

This PR modifies the import of the `urlopen` function to suit new versions of erddapy, where the `url_handling` module will be deprecated. It does not break compatibility with older versions (the `urlopen` function is available from the `erddapy.erddapy` module).

**Summary of changes**
  - Import 'urlopen' function from erddapy.erddapy module

Side note: while doing this change, I noticed that the `https://erddap-uncabled.oceanobservatories.org/uncabled/erddap` URL used in `test_standardise_variables_uncabled` is no longer valid, so checks will probably fail. There is an ERDDAP server at [https://erddap.dataexplorer.oceanobservatories.org/erddap/index.html](https://erddap.dataexplorer.oceanobservatories.org/erddap/index.html) but I wasn't sure of which dataset to use.
