### PR TITLE
Sort index

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       files: requirements-dev.txt
 
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 24.1.1
   hooks:
   - id: black
     language_version: python3
@@ -33,10 +33,10 @@ repos:
     - id: blackdoc
 
 - repo: https://github.com/econchick/interrogate
-  rev: 1.5.0
+  rev: 237be78f9c6135fc1a620d211cdfdc5d3885082b
   hooks:
     - id: interrogate
-      exclude: ^(docs|setup.py|tests)
+      exclude: ^(docs|tests)
       args: [--config=pyproject.toml]
 
 - repo: https://github.com/codespell-project/codespell
@@ -56,12 +56,12 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.9
+  rev: v0.1.15
   hooks:
     - id: ruff
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 1.5.3
+  rev: 1.7.0
   hooks:
     - id: pyproject-fmt
 

--- a/gliderpy/servers.py
+++ b/gliderpy/servers.py
@@ -3,7 +3,6 @@ Server names and aliases that point to an ERDDAP instance
 
 """
 
-
 server_vars = {
     "https://gliders.ioos.us/erddap": [
         "latitude",
@@ -30,4 +29,5 @@ server_parameter_rename = {
     "salinity (1)": "salinity",
     "temp (degree_celsius)": "temperature",
     "temperature (celsius)": "temperature",
+    "time (utc)": "time",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ ignore = [
   "tests",
   "tests/*",
 ]
-##
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+# Pyarrow will be required in pandas 3.0,
+# added here for better performance and to avoid a deprecation warning.
 cartopy
 check-manifest
 jupyter
@@ -6,6 +8,7 @@ nbconvert
 nbsphinx
 palettable
 pre-commit
+pyarrow
 pytest
 pytest-cov
 pytest-flake8


### PR DESCRIPTION
Glider data is not sorted at the source and this causes some confusing to the end users. In this PR we sorted it by datetime (index) when the user requests a pandas dataframe.