### PR TITLE
Format dates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast
@@ -27,7 +27,7 @@ repos:
     - id: blackdoc
 
 - repo: https://github.com/econchick/interrogate
-  rev: 1.5.0
+  rev: 1.7.0
   hooks:
     - id: interrogate
       exclude: ^(docs|tests)

--- a/gliderpy/fetchers.py
+++ b/gliderpy/fetchers.py
@@ -47,7 +47,10 @@ def standardise_df(glider_df: pd.DataFrame, dataset_url: str) -> pd.DataFrame:
     glider_df.columns = glider_df.columns.str.lower()
     glider_df = glider_df.set_index("time (utc)")
     glider_df = glider_df.rename(columns=server_parameter_rename)
-    glider_df.index = pd.to_datetime(glider_df.index)
+    glider_df.index = pd.to_datetime(
+        glider_df.index,
+        format="%Y-%m-%dT%H:%M:%SZ",
+    )
     # We need to sort b/c of the non-sequential submission of files due to
     # the nature of glider data transmission.
     glider_df = glider_df.sort_index()


### PR DESCRIPTION
If the date is ambiguous pandas defaults to individual parsing using `dateutil`, which is slower. B/c the dates in ERDDAP should always be in the same format it is safe to prescribe it and error out if the parsing fails.

@MathewBiddle this should avoid the parsing warnings you are seeing when using `gliderpy`.