### PR TITLE
handled optional dependencies in pyproject.toml as mentioned in #117

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,10 @@ dynamic = [
   "dependencies",
   "version",
 ]
+optional-dependencies.plotting = [ "cartopy", "matplotlib", "pandas-flavor" ]
 urls.documentation = "https://ioos.github.io/gliderpy"
 urls.homepage = "https://github.com/ioos/gliderpy"
 urls.repository = "https://github.com/ioos/gliderpy"
-
-[project.optional-dependencies]
-plotting = ["pandas_flavor", "matplotlib", "cartopy"]
 
 [tool.setuptools]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ urls.documentation = "https://ioos.github.io/gliderpy"
 urls.homepage = "https://github.com/ioos/gliderpy"
 urls.repository = "https://github.com/ioos/gliderpy"
 
+[project.optional-dependencies]
+plotting = ["pandas_flavor", "matplotlib", "cartopy"]
+
 [tool.setuptools]
 packages = [
   "gliderpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ erddapy
 gsw
 httpx
 pandas
-pandas-flavor
 xarray


### PR DESCRIPTION
the plotting dependencies have been made optional in the `pyproject.toml` file
the change made is

```toml
optional-dependencies.plotting = [ "cartopy", "matplotlib", "pandas-flavor" ]
```

additionally , the `pandas-flavor` library has been removed from the `requirements.txt` This ensures our plotting libraries are consistent throughout the code. 