### PR TITLE
Zizmor and trusted publishers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,23 +1,29 @@
-
-name: Documentation
+name: Build and Deploy docs
 
 on:
   pull_request:
   push:
-    branches:
-      - main
   release:
     types:
       - published
 
+defaults:
+  run:
+    shell: bash
+
+# no permissions by default
+permissions: {}
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup Micromamba ${{ matrix.python-version }}
       uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b  # v2.0.5
@@ -28,13 +34,11 @@ jobs:
           python=3 pip --channel conda-forge
 
     - name: Install library
-      shell: bash -l {0}
       run: |
         python -m pip install .[test,plotting,docs]
         conda install pandoc
 
     - name: Build documentation
-      shell: bash -l {0}
       run: |
         set -e
         jupyter nbconvert --to notebook --execute notebooks/00-quick_intro.ipynb --output=00-quick_intro-output.ipynb

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,10 +14,21 @@ defaults:
     shell: bash
 
 jobs:
-  packages:
+  pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gliderpy/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        # Should be enough for setuptools-scm
+        fetch-depth: 100
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -31,7 +42,7 @@ jobs:
       run: |
         python -m pip install --upgrade build
 
-    - name: Build binary wheel
+    - name: Build sdist and binary wheel
       run: python -m build --sdist --wheel . --outdir dist
 
     - name: CheckFiles
@@ -43,12 +54,9 @@ jobs:
     - name: Test wheels
       run: |
         cd dist && python -m pip install *.whl
-        python -m pip install --upgrade build twine
+        python -m pip install --upgrade twine
         python -m twine check *
 
     - name: Publish a Python distribution to PyPI
       if: success() && github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Full Tests
 
+# no permissions by default
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -19,6 +22,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,12 @@ repos:
   hooks:
     - id: pyproject-fmt
 
+- repo: https://github.com/woodruffw/zizmor-pre-commit
+  rev: v1.11.0
+  hooks:
+    - id: zizmor
+
+
 ci:
     autofix_commit_msg: |
         [pre-commit.ci] auto fixes from pre-commit.com hooks


### PR DESCRIPTION
The aim of this PR is to make the GitHub Action use a bit safer and implement Trusted Publishers. I'll send similar PRs to all projects that have packages on PyPI.